### PR TITLE
ROB-2312: Enable advanced filters

### DIFF
--- a/docs/ADVANCED_FILTERING.md
+++ b/docs/ADVANCED_FILTERING.md
@@ -21,9 +21,11 @@ When advanced filtering is enabled, the following rules are applied:
 
 ### Event Resources (api/v1/Event and events.k8s.io/v1/Event)
 
-- **Sent**: Only Warning events that are Created
+- **Sent**:
+  - Warning events that are Created
+  - Any event with Reason "Evicted" (regardless of Type - Normal or Warning)
 - **Filtered**:
-  - Normal events (regardless of operation)
+  - Normal events (unless Reason is "Evicted")
   - Warning events with Update or Delete operations
 
 ### Job Resources

--- a/pkg/filter/filter.go
+++ b/pkg/filter/filter.go
@@ -87,6 +87,25 @@ func (f *Filter) shouldSendEventResource(e event.Event) bool {
 		return false
 	}
 
+	// Check the event reason - always send Evicted events regardless of type
+	isEvictedEvent := false
+	switch obj := e.Obj.(type) {
+	case *api_v1.Event:
+		if obj.Reason == "Evicted" {
+			isEvictedEvent = true
+			logrus.Debugf("Event resource with reason 'Evicted' will be sent regardless of type")
+		}
+	case *events_v1.Event:
+		if obj.Reason == "Evicted" {
+			isEvictedEvent = true
+			logrus.Debugf("Event resource with reason 'Evicted' will be sent regardless of type")
+		}
+	}
+
+	if isEvictedEvent {
+		return true
+	}
+
 	// Check if it's a warning event
 	switch obj := e.Obj.(type) {
 	case *api_v1.Event:

--- a/pkg/filter/filter_test.go
+++ b/pkg/filter/filter_test.go
@@ -116,6 +116,30 @@ func TestShouldSendEventResource(t *testing.T) {
 			},
 			expected: true,
 		},
+		{
+			name: "Evicted Event Normal Type - Should Send",
+			event: event.Event{
+				Kind:   "Event",
+				Reason: "Created",
+				Obj: &api_v1.Event{
+					Type:   api_v1.EventTypeNormal,
+					Reason: "Evicted",
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "Evicted EventsV1 Normal Type - Should Send",
+			event: event.Event{
+				Kind:   "Event",
+				Reason: "Created",
+				Obj: &events_v1.Event{
+					Type:   api_v1.EventTypeNormal,
+					Reason: "Evicted",
+				},
+			},
+			expected: true,
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/handlers/cloudevent/cloudevent.go
+++ b/pkg/handlers/cloudevent/cloudevent.go
@@ -29,6 +29,7 @@ import (
 	"github.com/bitnami-labs/kubewatch/config"
 	"github.com/bitnami-labs/kubewatch/pkg/event"
 	"github.com/bitnami-labs/kubewatch/pkg/filter"
+	"github.com/bitnami-labs/kubewatch/pkg/metrics"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -97,6 +98,22 @@ func (m *CloudEvent) Handle(e event.Event) {
 	if !m.Filter.ShouldSendEvent(e) {
 		logrus.Debugf("Event filtered out - Kind: %s, Reason: %s, Name: %s", e.Kind, e.Reason, e.Name)
 		return
+	}
+
+	// Increment the sent metrics counter
+	// Map event.Reason to eventType for consistency with the total metrics
+	eventType := "unknown"
+	switch e.Reason {
+	case "Created":
+		eventType = "create"
+	case "Updated":
+		eventType = "update"
+	case "Deleted":
+		eventType = "delete"
+	}
+
+	if metrics.EventsSentTotal != nil {
+		metrics.EventsSentTotal.WithLabelValues(e.Kind, eventType).Inc()
 	}
 
 	m.Counter++ // TODO: do we have to worry about threadsafety here?


### PR DESCRIPTION
Allow running kubewatch without sending the following events:

Events: filter out Normal events (send only warning). Filter out Delete events
Jobs: Send only spec changes, or failures related updates
Pod: Send only spec changes, or failures related updates

## Tests performed
- Tested locally
- Tested on staging
- Automated tests