### PR TITLE
Fix: webhook readed only from the config file, not env

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -308,6 +308,9 @@ func (c *Config) CheckMissingResourceEnvvars() {
 	if (c.Handler.SlackWebhook.Slackwebhookurl == "") && (os.Getenv("KW_SLACK_WEBHOOK_URL") != "") {
 		c.Handler.SlackWebhook.Slackwebhookurl = os.Getenv("KW_SLACK_WEBHOOK_URL")
 	}
+	if (c.Handler.Webhook.Url == "") && (os.Getenv("KW_WEBHOOK_URL") != "") {
+		c.Handler.Webhook.Url = os.Getenv("KW_WEBHOOK_URL")
+	}
 }
 
 func (c *Config) Write() error {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -18,8 +18,8 @@ package config
 
 import (
 //"io/ioutil"
-//"os"
-//"testing"
+"os"
+"testing"
 )
 
 var configStr = `
@@ -48,30 +48,15 @@ var configStr = `
 }
 `
 
-//func TestLoadOK(t *testing.T) {
-//	content := []byte(configStr)
-//	tmpConfigFile, err := ioutil.TempFile(homeDir(), "kubewatch")
-//	if err != nil {
-//		t.Fatalf("TestLoad(): %+v", err)
-//	}
-//
-//	defer func() {
-//		_ = os.Remove(tmpConfigFile.Name())
-//	}()
-//
-//	if _, err := tmpConfigFile.Write(content); err != nil {
-//		t.Fatalf("TestLoad(): %+v", err)
-//	}
-//	if err := tmpConfigFile.Close(); err != nil {
-//		t.Fatalf("TestLoad(): %+v", err)
-//	}
-//
-//	ConfigFileName = "kubewatch"
-//
-//	c, err := New()
-//
-//	err = c.Load()
-//	if err != nil {
-//		t.Fatalf("TestLoad(): %+v", err)
-//	}
-//}
+func TestCheckMissingResourceEnvvars_Webhook(t *testing.T) {
+	expectedURL := "http://example.com/webhook"
+	os.Setenv("KW_WEBHOOK_URL", expectedURL)
+	defer os.Unsetenv("KW_WEBHOOK_URL")
+
+	c := &Config{}
+	c.CheckMissingResourceEnvvars()
+
+	if c.Handler.Webhook.Url != expectedURL {
+		t.Errorf("Expected Webhook URL to be %q, but got %q", expectedURL, c.Handler.Webhook.Url)
+	}
+}


### PR DESCRIPTION
This fixes an issue with reading the webhook URL from environment variables. It is particularly useful when the webhook URL contains authentication data.

I have tested this using my own build image: ghcr.io/tutunak/kubewatch:896adff Build log: https://github.com/tutunak/kubewatch/actions/runs/20718810312/job/59476693823

## Tests performed
- Tested locally
- Tested on staging