### PR TITLE
ROB-626: rebuild on fresh base to fix libcrypto3/openssl CVEs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,18 +2,19 @@
 # Patching CVE-2026-33811, CVE-2026-33814, CVE-2026-39817, CVE-2026-39819, CVE-2026-39820,
 # CVE-2026-39823, CVE-2026-39825, CVE-2026-39826, CVE-2026-39836, CVE-2026-42499, CVE-2026-42501,
 # CVE-2026-42504, CVE-2026-42507, CVE-2026-27145: requires Go >= 1.26.4
-FROM golang:1.26.4 AS builder
+# Build on the native build platform and cross-compile to the target arch with the
+# Go toolchain. This avoids running the Go compiler under QEMU emulation (which can
+# crash), so multi-arch builds (linux/amd64 + linux/arm64) work reliably.
+FROM --platform=$BUILDPLATFORM golang:1.26.4 AS builder
 
-RUN apt-get update && \
-    dpkg --add-architecture arm64 &&\
-    apt-get install -y --no-install-recommends build-essential && \
-    apt-get clean && \
-    mkdir -p "$GOPATH/src/github.com/bitnami-labs/kubewatch"
+RUN mkdir -p "$GOPATH/src/github.com/bitnami-labs/kubewatch"
 
 ADD . "$GOPATH/src/github.com/bitnami-labs/kubewatch"
 
+ARG TARGETOS=linux
+ARG TARGETARCH
 RUN cd "$GOPATH/src/github.com/bitnami-labs/kubewatch" && \
-    CGO_ENABLED=0 GOOS=linux GOARCH=$(dpkg --print-architecture) go build -a --installsuffix cgo --ldflags="-s" -o /kubewatch
+    CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -a --installsuffix cgo --ldflags="-s" -o /kubewatch
 
 # Patching CVE-2026-4046, CVE-2026-4437: requires glibc >= 2.44, provided by chainguard/bash built after May 2026
 FROM cgr.dev/chainguard/bash:latest


### PR DESCRIPTION
Sub-issue [ROB-626](https://linear.app/robusta/issue/ROB-626) of ROB-595. Fixes the base-image openssl/libcrypto3 CVEs flagged for `devel/kubewatch` in the 2026-07-14 Vanta scan.

## Fix
The vulnerable `libcrypto3`/`libssl3` come from the `cgr.dev/chainguard/bash` runtime base. A fresh `--pull` rebuild picks up the patched base (libcrypto3 → 3.6.2-r5+), clearing:
CVE-2026-34180/34181/34182/34183/42764/42765/45445/45447/7383/9076.

Also switched the Go builder to cross-compilation (`FROM --platform=$BUILDPLATFORM golang` + `GOARCH=$TARGETARCH`) so multi-arch (amd64+arm64) builds don't run the Go compiler under QEMU emulation — which was crashing with a nil-pointer panic when building amd64 on an arm64 host.

## Validation
Built multi-arch and pushed `devel/kubewatch:v2.15.0-cve20260714`; `docker scout` re-checked for the target CVEs (see PR checks / ticket). Deploying to `avi-test-cluster2` forwarders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)